### PR TITLE
fix base64 errors

### DIFF
--- a/GDSavefileEditor.py
+++ b/GDSavefileEditor.py
@@ -80,7 +80,7 @@ def main():
                     with open(os.path.join(SAVE_FILE_PATH, save_file), 'rb') as f:
                         encrypted_data = f.read()
 
-                    decrypted_data = xor_bytes(encrypted_data, 11)
+                    decrypted_data = xor_bytes(encrypted_data[:len(encrypted_data) // 4 * 4], 11)
                     decoded_data = base64.b64decode(decrypted_data, altchars=b'-_')
                     decompressed_data = zlib.decompress(decoded_data[10:], -zlib.MAX_WBITS)
 


### PR DESCRIPTION
geometry dash sometimes adds up to 3 bytes of garbage to end of `CC*.dat` files

so I changed it to round down multiple of 4 (length of base64 encoded string is always multiple of 4)

that solution worked for me in https://gdccdated.glitch.me/index.xhtml (it loads save file every time I tried without random errors)

also I think this fixes https://github.com/WEGFan/Geometry-Dash-Savefile-Editor/issues/5